### PR TITLE
Updated dependencies for version 1.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2024-06-20
+
+### Changed in 1.1.3
+
+- Updated `senzing-commons-java` dependency from version `3.2.0` to `3.3.0`
+- Updated `senzing-listener` dependency from version `0.5.7` to `0.5.9`
+- Updated  `postgresql` dependency from version `42.7.2` to `42.7.3`
+- Updated `jackson-annotations` dependency from version `2.16.1` to `2.17.1`
+- Updated `jackson-databind` dependency from version `2.16.1` to `2.17.1`
+- Updated `jackson-core` dependency from version `2.16.1` to `2.17.1`
+- Updated `jackson-module-jaxb-annotations` dependency from version `2.16.1` to `2.17.1`
+- Updated `jackson-datatype-joda` dependency from version `2.16.1` to `2.17.1`
+- Updated Amazon `sqs` dependney from version `2.24.12` to `2.26.4`
+- Updated `amqp-client` dependency from version `5.20.0` to `5.21.0`
+- Updated `slf4j-api` dependency from version `2.0.12` to `2.0.13`
+- Updated `slf4j-simple` dependency from version `2.0.12` to `2.0.13`
+- Updated `maven-compiler-plugin` dependency from version `3.12.1` to `3.13.0`
+- Updated `maven-source-plugin` dependency from version `3.3.0` to `3.3.1`
+- Updated `maven-javadoc-plugin` dependency from version `3.6.3` to `3.7.0`
+- Updated `maven-shade-plugin` dependency from version `3.5.2` to `3.6.0`
+
 ## [1.1.2] - 2024-03-21
 
 ### Changed in 1.1.2

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>data-mart-replicator</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.2</version>
+  <version>1.1.3 </version>
   <name>Senzing G2 Data Mart Replicator</name>
   <description>The Senzing listener implementation that replicates data to the data mart.</description>
   <url>http://github.com/senzing-garage/g2-sdk-java</url>
@@ -31,12 +31,12 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>[3.2.0,3.9999999.9999999]</version>
+      <version>[3.3.0,3.9999999.9999999]</version>
     </dependency>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-listener</artifactId>
-      <version>[0.5.7,0.5.9999999]</version>
+      <version>[0.5.9,0.5.9999999]</version>
     </dependency>
     <dependency>
       <groupId>org.xerial</groupId>
@@ -46,27 +46,27 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.7.2</version>
+      <version>42.7.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.16.1</version>
+      <version>2.17.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.16.1</version>
+      <version>2.17.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.16.1</version>
+      <version>2.17.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.16.1</version>
+      <version>2.17.1</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -82,27 +82,27 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.24.12</version>
+      <version>2.26.4</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-      <version>5.20.0</version>
+      <version>5.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
-      <version>2.16.1</version>
+      <version>2.17.1</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.12</version>
+      <version>2.0.13</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>2.0.12</version>
+      <version>2.0.13</version>
     </dependency>
 
     <!-- add dependencies that were present in JDK 8, but optional in JDK 11 -->
@@ -138,7 +138,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.12.1</version>
+        <version>3.13.0</version>
         <configuration>
           <compilerArgs>
             <arg>-Xlint:unchecked</arg>
@@ -149,7 +149,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.3.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -162,7 +162,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.3</version>
+        <version>3.7.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -175,7 +175,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.5.2</version>
+        <version>3.6.0</version>
         <configuration>
           <createDependencyReducedPom>false</createDependencyReducedPom>
           <filters>


### PR DESCRIPTION
- Updated `senzing-commons-java` dependency from version `3.2.0` to `3.3.0`
- Updated `senzing-listener` dependency from version `0.5.7` to `0.5.9`
- Updated  `postgresql` dependency from version `42.7.2` to `42.7.3`
- Updated `jackson-annotations` dependency from version `2.16.1` to `2.17.1`
- Updated `jackson-databind` dependency from version `2.16.1` to `2.17.1`
- Updated `jackson-core` dependency from version `2.16.1` to `2.17.1`
- Updated `jackson-module-jaxb-annotations` dependency from version `2.16.1` to `2.17.1`
- Updated `jackson-datatype-joda` dependency from version `2.16.1` to `2.17.1`
- Updated Amazon `sqs` dependney from version `2.24.12` to `2.26.4`
- Updated `amqp-client` dependency from version `5.20.0` to `5.21.0`
- Updated `slf4j-api` dependency from version `2.0.12` to `2.0.13`
- Updated `slf4j-simple` dependency from version `2.0.12` to `2.0.13`
- Updated `maven-compiler-plugin` dependency from version `3.12.1` to `3.13.0`
- Updated `maven-source-plugin` dependency from version `3.3.0` to `3.3.1`
- Updated `maven-javadoc-plugin` dependency from version `3.6.3` to `3.7.0`
- Updated `maven-shade-plugin` dependency from version `3.5.2` to `3.6.0`
