### PR TITLE
Updated dependencies for version 1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.4] - 2024-08-02
+
+### Changed in 1.1.4
+
+- Updated `senzing-listener` dependency from version `0.5.9` to `1.0.0`
+- Updated `jackson-annotations` dependency from version `2.17.1` to `2.17.2`
+- Updated `jackson-databind` dependency from version `2.17.1` to `2.17.2`
+- Updated `jackson-core` dependency from version `2.17.1` to `2.17.2`
+- Updated `jackson-module-jaxb-annotations` dependency from version `2.17.1` to `2.17.2`
+- Updated `jackson-datatype-joda` dependency from version `2.17.1` to `2.17.2`
+- Updated `junit-jupiter` dependency from version `5.10.2` to `5.10.3`
+- Updated Amazon `sqs` dependney from version `2.26.4` to `2.26.27`
+- Updated `maven-javadoc-plugin` dependency from version `3.7.0` to `3.8.0`
+
 ## [1.1.3] - 2024-06-20
 
 ### Changed in 1.1.3

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>data-mart-replicator</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.3 </version>
+  <version>1.1.4 </version>
   <name>Senzing G2 Data Mart Replicator</name>
   <description>The Senzing listener implementation that replicates data to the data mart.</description>
   <url>http://github.com/senzing-garage/g2-sdk-java</url>
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-listener</artifactId>
-      <version>[0.5.9,0.5.9999999]</version>
+      <version>[1.0.0,1.9999999.9999999]</version>
     </dependency>
     <dependency>
       <groupId>org.xerial</groupId>
@@ -51,27 +51,27 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.17.1</version>
+      <version>2.17.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.17.1</version>
+      <version>2.17.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.17.1</version>
+      <version>2.17.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.17.1</version>
+      <version>2.17.2</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.10.2</version>
+      <version>5.10.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.26.4</version>
+      <version>2.26.27</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
-      <version>2.17.1</version>
+      <version>2.17.2</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -162,7 +162,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.8.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
- Updated `senzing-listener` dependency from version `0.5.9` to `1.0.0`
- Updated `jackson-annotations` dependency from version `2.17.1` to `2.17.2`
- Updated `jackson-databind` dependency from version `2.17.1` to `2.17.2`
- Updated `jackson-core` dependency from version `2.17.1` to `2.17.2`
- Updated `jackson-module-jaxb-annotations` dependency from version `2.17.1` to `2.17.2`
- Updated `jackson-datatype-joda` dependency from version `2.17.1` to `2.17.2`
- Updated `junit-jupiter` dependency from version `5.10.2` to `5.10.3`
- Updated Amazon `sqs` dependney from version `2.26.4` to `2.26.27`
- Updated `maven-javadoc-plugin` dependency from version `3.7.0` to `3.8.0`
