### PR TITLE
Dependency updates for version 1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.5] - 2024-10-08
+
+### Changed in 1.1.5
+
+- Updated `senzing-commons` dependency from version `3.3.0` to `3.3.1`
+- Updated `senzing-listener` dependency from version `1.0.0` to `1.0.1`
+- Updated `jackson-xxxxx` dependencies from version `2.17.2` to `2.18.0`
+- Updated `amqp-client` dependency from version `5.21.0` to `5.22.0`
+- Updated Amazon `sqs` dependney from version `2.26.27` to `2.28.17`
+- Updated `slf4j-xxxxx` dependencies from version `2.0.13` to `2.0.16`
+- Updated `junit-jupiter` dependency from version `5.10.3` to `5.11.2`
+- Updated `postgresql` dependency from version `42.7.3` to `42.7.4`
+- Updated `maven-javadoc-plugin` dependency from version `3.8.0` to `3.10.1`
+
 ## [1.1.4] - 2024-08-02
 
 ### Changed in 1.1.4

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>data-mart-replicator</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.4</version>
+  <version>1.1.5</version>
   <name>Senzing G2 Data Mart Replicator</name>
   <description>The Senzing listener implementation that replicates data to the data mart.</description>
   <url>http://github.com/senzing-garage/g2-sdk-java</url>
@@ -31,12 +31,12 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>[3.3.0,3.9999999.9999999]</version>
+      <version>[3.3.1,3.9999999.9999999]</version>
     </dependency>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-listener</artifactId>
-      <version>[1.0.0,1.9999999.9999999]</version>
+      <version>[1.0.1,1.9999999.9999999]</version>
     </dependency>
     <dependency>
       <groupId>org.xerial</groupId>
@@ -46,32 +46,32 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.7.3</version>
+      <version>42.7.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.17.2</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.17.2</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.17.2</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.17.2</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.10.3</version>
+      <version>5.11.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -82,27 +82,27 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.26.27</version>
+      <version>2.28.17</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-      <version>5.21.0</version>
+      <version>5.22.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
-      <version>2.17.2</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.13</version>
+      <version>2.0.16</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>2.0.13</version>
+      <version>2.0.16</version>
     </dependency>
 
     <!-- add dependencies that were present in JDK 8, but optional in JDK 11 -->
@@ -162,7 +162,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>3.10.1</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
- Updated `senzing-commons` dependency from version `3.3.0` to `3.3.1`
- Updated `senzing-listener` dependency from version `1.0.0` to `1.0.1`
- Updated `jackson-xxxxx` dependencies from version `2.17.2` to `2.18.0`
- Updated `amqp-client` dependency from version `5.21.0` to `5.22.0`
- Updated Amazon `sqs` dependney from version `2.26.27` to `2.28.17`
- Updated `slf4j-xxxxx` dependencies from version `2.0.13` to `2.0.16`
- Updated `junit-jupiter` dependency from version `5.10.3` to `5.11.2`
- Updated `postgresql` dependency from version `42.7.3` to `42.7.4`
- Updated `maven-javadoc-plugin` dependency from version `3.8.0` to `3.10.1`
