### PR TITLE
Updated dependencies for version 1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.6] - 2024-12-06
+
+### Changed in 1.1.6
+
+- Updated `senzing-commons` dependency from version `3.3.0` to `3.3.2`
+- Updated `senzing-listener` dependency from version `1.0.0` to `1.0.2`
+- Updated `jackson-xxxxx` dependencies from version `2.18.0` to `2.18.2`
+- Updated `amqp-client` dependency from version `5.22.0` to `5.23.0`
+- Updated Amazon `sqs` dependency from version `2.28.17` to `2.29.26`
+- Updated `junit-jupiter` dependency from version `5.11.2` to `5.11.3`
+- Updated `maven-javadoc-plugin` dependency from version `3.10.1` to `3.11.1`
+
 ## [1.1.5] - 2024-10-08
 
 ### Changed in 1.1.5

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>data-mart-replicator</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.5</version>
+  <version>1.1.6</version>
   <name>Senzing G2 Data Mart Replicator</name>
   <description>The Senzing listener implementation that replicates data to the data mart.</description>
   <url>http://github.com/senzing-garage/g2-sdk-java</url>
@@ -31,12 +31,12 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>[3.3.1,3.9999999.9999999]</version>
+      <version>[3.3.2,3.9999999.9999999]</version>
     </dependency>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-listener</artifactId>
-      <version>[1.0.1,1.9999999.9999999]</version>
+      <version>[1.0.2,1.9999999.9999999]</version>
     </dependency>
     <dependency>
       <groupId>org.xerial</groupId>
@@ -51,27 +51,27 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.18.0</version>
+      <version>2.18.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.18.0</version>
+      <version>2.18.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.18.0</version>
+      <version>2.18.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.18.0</version>
+      <version>2.18.2</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.11.2</version>
+      <version>5.11.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -82,17 +82,17 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.28.17</version>
+      <version>2.29.26</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-      <version>5.22.0</version>
+      <version>5.23.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
-      <version>2.18.0</version>
+      <version>2.18.2</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -162,7 +162,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.10.1</version>
+        <version>3.11.1</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
Updated dependencies for version 1.1.6:

- Updated `senzing-commons` dependency from version `3.3.0` to `3.3.2`
- Updated `senzing-listener` dependency from version `1.0.0` to `1.0.2`
- Updated `jackson-xxxxx` dependencies from version `2.18.0` to `2.18.2`
- Updated `amqp-client` dependency from version `5.22.0` to `5.23.0`
- Updated Amazon `sqs` dependency from version `2.28.17` to `2.29.26`
- Updated `junit-jupiter` dependency from version `5.11.2` to `5.11.3`
- Updated `maven-javadoc-plugin` dependency from version `3.10.1` to `3.11.1`