### PR TITLE
Updated dependencies for version 1.2.1 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2025-04-16
+
+### Changed in 1.2.1
+
+- Updated dependencies:
+  - Updated `senzing-commons-java` dependencies from version `3.3.2` to `3.3.3`
+  - Updated `postgresql` dependency from version `42.7.4` to `42.7.5`
+  - Updated `jackson-xxxx` dependencies from version `2.18.2` to `2.18.3`
+  - Updated `junit-jupiter` from version `5.11.3` to `5.12.2`
+  - Updated Amazon `sqs` from version `2.29.26` to `2.31.22`
+  - Updated `amqp-client` dependencies from version `5.23.0` to `5.25.0`
+  - Updated `slf4j-xxxxx` dependencies from version `2.0.16` to `2.0.17`
+  - Updated `jaxb-core` dependencies from version `3.0.0` to `3.0.2`
+  - Updated `maven-surefire-plugin` from version `3.5.2` to `3.5.3`
+  - Updated `maven-compiler-plugin` from version `3.13.0` to `3.14.0`
+  - Updated `maven-javadoc-plugin` from version `3.11.1` to `3.11.2`
+
 ## [1.2.0] - 2024-12-12
 
 ### Changed in 1.2.0

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>data-mart-replicator</artifactId>
   <packaging>jar</packaging>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
   <name>Senzing G2 Data Mart Replicator</name>
   <description>The Senzing listener implementation that replicates data to the data mart.</description>
   <url>http://github.com/senzing-garage/g2-sdk-java</url>
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>[3.3.2,3.9999999.9999999]</version>
+      <version>[3.3.3,3.9999999.9999999]</version>
     </dependency>
     <dependency>
       <groupId>org.xerial</groupId>
@@ -41,32 +41,32 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.7.4</version>
+      <version>42.7.5</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.18.2</version>
+      <version>2.18.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.18.2</version>
+      <version>2.18.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.18.2</version>
+      <version>2.18.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.18.2</version>
+      <version>2.18.3</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.11.3</version>
+      <version>5.12.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -77,34 +77,34 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.29.26</version>
+      <version>2.31.22</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-      <version>5.23.0</version>
+      <version>5.25.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
-      <version>2.18.2</version>
+      <version>2.18.3</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.16</version>
+      <version>2.0.17</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>2.0.16</version>
+      <version>2.0.17</version>
     </dependency>
 
     <!-- add dependencies that were present in JDK 8, but optional in JDK 11 -->
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-core</artifactId>
-      <version>3.0.0</version>
+      <version>3.0.2</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>
@@ -133,7 +133,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.13.0</version>
+        <version>3.14.0</version>
         <configuration>
           <compilerArgs>
             <arg>-Xlint:unchecked</arg>
@@ -144,7 +144,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.5.2</version>
+        <version>3.5.3</version>
         <configuration>
           <systemPropertyVariables>
             <project.build.directory>${project.build.directory}</project.build.directory>
@@ -176,7 +176,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.11.1</version>
+        <version>3.11.2</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
- Updated dependencies:
  - Updated `senzing-commons-java` dependencies from version `3.3.2` to `3.3.3`
  - Updated `postgresql` dependency from version `42.7.4` to `42.7.5`
  - Updated `jackson-xxxx` dependencies from version `2.18.2` to `2.18.3`
  - Updated `junit-jupiter` from version `5.11.3` to `5.12.2`
  - Updated Amazon `sqs` from version `2.29.26` to `2.31.22`
  - Updated `amqp-client` dependencies from version `5.23.0` to `5.25.0`
  - Updated `slf4j-xxxxx` dependencies from version `2.0.16` to `2.0.17`
  - Updated `jaxb-core` dependencies from version `3.0.0` to `3.0.2`
  - Updated `maven-surefire-plugin` from version `3.5.2` to `3.5.3`
  - Updated `maven-compiler-plugin` from version `3.13.0` to `3.14.0`
  - Updated `maven-javadoc-plugin` from version `3.11.1` to `3.11.2`
