### PR TITLE
Updated dependencies for version 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2025-06-09
+
+### Changed in 1.2.2
+
+- Updated dependencies:
+  - Updated `senzing-commons-java` dependencies from version `3.3.3` to `3.3.4`
+  - Updated `postgresql` dependency from version `42.7.5` to `42.7.6`
+  - Updated `jackson-xxxx` dependencies from version `2.18.3` to `2.19.0`
+  - Updated `junit-jupiter` from version `5.12.2` to `5.13.1`
+  - Updated Amazon `sqs` from version `2.31.22` to `2.31.59`
+
 ## [1.2.1] - 2025-04-16
 
 ### Changed in 1.2.1

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>data-mart-replicator</artifactId>
   <packaging>jar</packaging>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <name>Senzing G2 Data Mart Replicator</name>
   <description>The Senzing listener implementation that replicates data to the data mart.</description>
   <url>http://github.com/senzing-garage/g2-sdk-java</url>
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>[3.3.3,3.9999999.9999999]</version>
+      <version>[3.3.4,3.9999999.9999999]</version>
     </dependency>
     <dependency>
       <groupId>org.xerial</groupId>
@@ -41,32 +41,32 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.7.5</version>
+      <version>42.7.6</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.18.3</version>
+      <version>2.19.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.18.3</version>
+      <version>2.19.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.18.3</version>
+      <version>2.19.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.18.3</version>
+      <version>2.19.0</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.12.2</version>
+      <version>5.13.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.31.22</version>
+      <version>2.31.59</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
-      <version>2.18.3</version>
+      <version>2.19.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
  - Updated `senzing-commons-java` dependencies from version `3.3.3` to `3.3.4`
  - Updated `postgresql` dependency from version `42.7.5` to `42.7.6`
  - Updated `jackson-xxxx` dependencies from version `2.18.3` to `2.19.0`
  - Updated `junit-jupiter` from version `5.12.2` to `5.13.1`
  - Updated Amazon `sqs` from version `2.31.22` to `2.31.59`
