### PR TITLE
Updated dependencies for version 1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3] - 2025-08-12
+
+### Changed in 1.2.3
+
+- Fixed compile-time warnings.
+- Updated dependencies:
+  - Updated `senzing-commons-java` dependencies from version `3.3.4` to `3.3.6`
+  - Updated `jackson-xxxx` dependencies from version `2.19.0` to `2.19.2`
+  - Updated `junit-jupiter` from version `5.13.1` to `5.13.4`
+  - Updated `sqlite-jdbc` from version `3.42.0.1` to `3.50.3.0`
+  - Updated `amqp-client` from version `5.25.0` to `5.26.0`
+  - Updated `jaxb-impl` from version `2.3.1` to `2.3.9`
+  - Updated `javassist` from version `3.27.0-GA` to `3.30.2-GA`
+  - Updated Amazon `sqs` from version `2.31.59` to `2.32.19`
+
 ## [1.2.2] - 2025-06-09
 
 ### Changed in 1.2.2

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>data-mart-replicator</artifactId>
   <packaging>jar</packaging>
-  <version>1.2.2</version>
+  <version>1.2.3</version>
   <name>Senzing G2 Data Mart Replicator</name>
   <description>The Senzing listener implementation that replicates data to the data mart.</description>
   <url>http://github.com/senzing-garage/g2-sdk-java</url>
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>[3.3.4,3.9999999.9999999]</version>
+      <version>[3.3.6,3.9999999.9999999]</version>
     </dependency>
     <dependency>
       <groupId>org.xerial</groupId>
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.31.78</version>
+      <version>2.32.19</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>


### PR DESCRIPTION
- Fixed compile-time warnings.
- Updated dependencies:
  - Updated `senzing-commons-java` dependencies from version `3.3.4` to `3.3.6`
  - Updated `jackson-xxxx` dependencies from version `2.19.0` to `2.19.2`
  - Updated `junit-jupiter` from version `5.13.1` to `5.13.4`
  - Updated `sqlite-jdbc` from version `3.42.0.1` to `3.50.3.0`
  - Updated `amqp-client` from version `5.25.0` to `5.26.0`
  - Updated `jaxb-impl` from version `2.3.1` to `2.3.9`
  - Updated `javassist` from version `3.27.0-GA` to `3.30.2-GA`
  - Updated Amazon `sqs` from version `2.31.59` to `2.32.19`
