### PR TITLE
Updated the VS Code editor.formatOnSave settings to exclude only Java

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,8 @@
   "[yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "editor.formatOnSave": false
+  "editor.formatOnSave": true,
+  "[java]": {
+     "editor.formatOnSave": false
+  }
 }


### PR DESCRIPTION
Changes for `.vscode/settings` as follows:

```
  "editor.formatOnSave": true,
  "[java]": {
     "editor.formatOnSave": false
  }
```