### PR TITLE
#237 Migrate workflows to centralized SDK version matrix and fix job outputs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "maven"
+    assignees:
+      - "barrycaceres"
     cooldown:
       default-days: 21
     directory: "/"

--- a/.github/workflows/maven-darwin.yaml
+++ b/.github/workflows/maven-darwin.yaml
@@ -14,7 +14,16 @@ concurrency:
 permissions: {}
 
 jobs:
+
+  sdk-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      senzingsdk-versions: ${{ steps.cfg.outputs.senzingsdk-versions }}
+    steps:
+      - id: cfg
+        uses: senzing-factory/build-resources/sdk-versions@v4
   maven-darwin:
+    needs: sdk-versions
     permissions:
       contents: read
       pull-requests: write
@@ -24,7 +33,7 @@ jobs:
       matrix:
         java-distribution: ["temurin"]
         java-version: ["17", "21"]
-        senzingsdk-version: [production-v4, staging-v4]
+        senzingsdk-version: ${{ fromJSON(needs.sdk-versions.outputs.senzingsdk-versions) }}
 
     steps:
       - name: checkout repository

--- a/.github/workflows/maven-darwin.yaml
+++ b/.github/workflows/maven-darwin.yaml
@@ -14,7 +14,6 @@ concurrency:
 permissions: {}
 
 jobs:
-
   sdk-versions:
     runs-on: ubuntu-latest
     outputs:
@@ -22,6 +21,7 @@ jobs:
     steps:
       - id: cfg
         uses: senzing-factory/build-resources/sdk-versions@v4
+
   maven-darwin:
     needs: sdk-versions
     permissions:

--- a/.github/workflows/maven-linux.yaml
+++ b/.github/workflows/maven-linux.yaml
@@ -15,7 +15,6 @@ concurrency:
 permissions: {}
 
 jobs:
-
   sdk-versions:
     runs-on: ubuntu-latest
     outputs:
@@ -23,6 +22,7 @@ jobs:
     steps:
       - id: cfg
         uses: senzing-factory/build-resources/sdk-versions@v4
+
   maven-linux:
     needs: sdk-versions
     permissions:

--- a/.github/workflows/maven-linux.yaml
+++ b/.github/workflows/maven-linux.yaml
@@ -15,7 +15,16 @@ concurrency:
 permissions: {}
 
 jobs:
+
+  sdk-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      senzingsdk-versions: ${{ steps.cfg.outputs.senzingsdk-versions }}
+    steps:
+      - id: cfg
+        uses: senzing-factory/build-resources/sdk-versions@v4
   maven-linux:
+    needs: sdk-versions
     permissions:
       contents: read
       pull-requests: write
@@ -25,7 +34,7 @@ jobs:
       matrix:
         java-version: ["17", "21"]
         java-distribution: ["temurin"]
-        senzingsdk-version: [production-v4, staging-v4]
+        senzingsdk-version: ${{ fromJSON(needs.sdk-versions.outputs.senzingsdk-versions) }}
 
     steps:
       - name: checkout repository

--- a/.github/workflows/maven-windows.yaml
+++ b/.github/workflows/maven-windows.yaml
@@ -14,7 +14,6 @@ concurrency:
 permissions: {}
 
 jobs:
-
   sdk-versions:
     runs-on: ubuntu-latest
     outputs:
@@ -22,6 +21,7 @@ jobs:
     steps:
       - id: cfg
         uses: senzing-factory/build-resources/sdk-versions@v4
+
   maven-windows:
     needs: sdk-versions
     permissions:

--- a/.github/workflows/maven-windows.yaml
+++ b/.github/workflows/maven-windows.yaml
@@ -14,7 +14,16 @@ concurrency:
 permissions: {}
 
 jobs:
+
+  sdk-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      senzingsdk-versions: ${{ steps.cfg.outputs.senzingsdk-versions }}
+    steps:
+      - id: cfg
+        uses: senzing-factory/build-resources/sdk-versions@v4
   maven-windows:
+    needs: sdk-versions
     permissions:
       contents: read
       pull-requests: write
@@ -24,7 +33,7 @@ jobs:
       matrix:
         java-version: ["17", "21"]
         java-distribution: ["temurin"]
-        senzingsdk-version: [production-v4, staging-v4]
+        senzingsdk-version: ${{ fromJSON(needs.sdk-versions.outputs.senzingsdk-versions) }}
 
     steps:
       - name: checkout repository

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -14,6 +14,7 @@
     "AWITH",
     "awssdk",
     "backgrounding",
+    "barrycaceres",
     "BIGSERIAL",
     "boringssl",
     "Caceres",


### PR DESCRIPTION
## Summary

- Migrate hardcoded `senzingsdk-version` matrix entries to use centralized `senzing-factory/build-resources/sdk-versions@v4` composite action
- Remove deprecated `outputs: status: ${{ job.status }}` blocks from jobs
- Replace `.outputs.status` references with `.result` in slack notification jobs
- Fix `.claude/settings.json`

## Test plan

- [ ] Verify `sdk-versions` job runs and provides correct matrix values
- [ ] Verify test/build jobs receive matrix values via `fromJSON()`
- [ ] Verify slack notifications use `.result` correctly

---

Resolves #237