### PR TITLE
Fix match key parser for "(Ambiguous)" suffix (#210)

### DIFF
--- a/src/main/java/com/senzing/datamart/model/SzRelationship.java
+++ b/src/main/java/com/senzing/datamart/model/SzRelationship.java
@@ -322,14 +322,17 @@ public class SzRelationship {
             return component; // no parenthesized section
         }
 
-        // Find unescaped closing parenthesis (search from end)
-        int closeParen = -1;
-        for (int i = len - 1; i > openParen; i--) {
-            if (text[i] == ')' && !isEscaped(text, i)) {
-                closeParen = i;
-                break;
-            }
+        // The '(' must immediately follow the identifier with no whitespace.
+        // This distinguishes role-bearing components like +REL_POINTER(min:max)
+        // from the " (Ambiguous)" suffix the engine appends to ambiguous match keys.
+        if (openParen == 0 || Character.isWhitespace(text[openParen - 1])) {
+            return component;
         }
+
+        // Find the first unescaped closing parenthesis after the opening one.
+        // We search forward (not from the end) so that a trailing suffix like
+        // " (Ambiguous)" does not capture the wrong closing paren.
+        int closeParen = findNextUnescaped(text, ')', openParen + 1, len);
         if (closeParen < 0) {
             logWarning("Missing closing parenthesis in match key component: "
                        + component);

--- a/src/test/java/com/senzing/datamart/model/SzRelationshipTest.java
+++ b/src/test/java/com/senzing/datamart/model/SzRelationshipTest.java
@@ -702,6 +702,23 @@ class SzRelationshipTest {
     }
 
     @Test
+    void testStaticGetReverseMatchKeyAmbiguousSuffix() {
+        // Engine appends " (Ambiguous)" to ambiguous match keys.
+        // The space before '(' means it is NOT a role-bearing component.
+        String matchKey = "+SSN (Ambiguous)";
+        String reversed = SzRelationship.getReverseMatchKey(matchKey);
+        assertEquals("+SSN (Ambiguous)", reversed);
+    }
+
+    @Test
+    void testStaticGetReverseMatchKeyAmbiguousSuffixWithRelPointer() {
+        // Combined disclosed + ambiguous: only the REL_POINTER gets reversed
+        String matchKey = "+REL_POINTER(HUSBAND:WIFE) (Ambiguous)";
+        String reversed = SzRelationship.getReverseMatchKey(matchKey);
+        assertEquals("+REL_POINTER(WIFE:HUSBAND) (Ambiguous)", reversed);
+    }
+
+    @Test
     void testStaticGetReverseMatchKeyRealEngineOutput() {
         // Verified output from Senzing 4.3.0 engine
         String forward = "+REL_POINTER(GLOBAL\\:PARENT:SUBSIDIARY)";


### PR DESCRIPTION
SzRelationship.java:
- Fixed reverseRoleBearingComponent() to require no whitespace before the opening parenthesis, distinguishing role-bearing components like +REL_POINTER(min:max) from the " (Ambiguous)" suffix the engine appends to ambiguous match keys
- Changed closing parenthesis search from backward (last unescaped ')') to forward (first unescaped ')' after opening paren), preventing the ')' in " (Ambiguous)" from being mistaken for the role-bearing component's closing paren

SzRelationshipTest.java:
- Added testStaticGetReverseMatchKeyAmbiguousSuffix: verifies "+SSN (Ambiguous)" passes through unchanged
- Added testStaticGetReverseMatchKeyAmbiguousSuffixWithRelPointer: verifies "+REL_POINTER(HUSBAND:WIFE) (Ambiguous)" correctly reverses only the role-bearing component

# Pull request questions

## Which issue does this address

Issue number: #nnn

## Why was change needed

???

## What does change improve

???


---

Resolves #210