### PR TITLE
Release 2.0.1

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -22,16 +22,6 @@ Critical topics documented in FAQs:
 - Backpressure and throttling mechanisms
 - Multi-process safety with lease-based coordination
 
-## IMPORTANT: Code Modification Policy
-
-**DO NOT modify files directly. Always make suggestions instead and wait for user approval.**
-
-- The ONLY file you are permitted to edit directly is .claude/CLAUDE.md
-- For ALL other files, provide suggestions and recommendations
-- Wait for user review and approval before any changes are made
-- Default to suggesting changes rather than implementing them
-- This ensures the user maintains full control over all code modifications
-
 ## Project Overview
 
 The Senzing Data Mart Replicator is a multi-threaded Java application that consumes Senzing INFO messages from message queues (Amazon SQS, RabbitMQ, or SQL-based), retrieves entity data via the Senzing SDK, and replicates statistics to a data mart database (PostgreSQL or SQLite).
@@ -66,7 +56,7 @@ Output: `target/site/apidocs/`
 
 ### Running the Application
 ```bash
-java -jar target/data-mart-replicator-2.0.0.jar --help
+java -jar target/data-mart-replicator-server.jar --help
 ```
 
 ### Clean Build
@@ -219,16 +209,16 @@ The JaCoCo profile must be activated with `-P jacoco`. The coverage report is ge
 
 **Core:**
 - `sz-sdk` 4.3.0+ - Senzing Core SDK (minimum 4.3.0 for match key escaping)
-- `sz-sdk-auto` 0.5.1 - Auto-configuration
-- `senzing-commons` 4.0.0 - Shared utilities
+- `sz-sdk-auto` 1.0.1 - Auto-configuration
+- `senzing-commons` 4.0.1 - Shared utilities
 
 **Database:**
 - `postgresql` 42.7.11 - PostgreSQL JDBC driver
-- `sqlite-jdbc` 3.53.0.0 - SQLite JDBC driver
+- `sqlite-jdbc` 3.53.1.0 - SQLite JDBC driver
 
 **Messaging:**
 - `amqp-client` 5.30.0 - RabbitMQ client
-- `sqs` 2.43.0 - AWS SQS SDK
+- `sqs` 2.44.10 - AWS SQS SDK
 
 **Serialization:**
 - `jackson-*` 2.21.x - JSON processing

--- a/.github/workflows/bearer.yaml
+++ b/.github/workflows/bearer.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/maven-darwin.yaml
+++ b/.github/workflows/maven-darwin.yaml
@@ -37,11 +37,11 @@ jobs:
 
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v5.2.0
         with:
           distribution: ${{ matrix.java-distribution }}
           java-version: ${{ matrix.java-version }}
@@ -49,7 +49,7 @@ jobs:
       - name: Mint staging tap token
         if: matrix.senzingsdk-version != 'production-v4'
         id: staging-token
-        uses: actions/create-github-app-token@v3.1.1
+        uses: actions/create-github-app-token@v3.2.0
         with:
           client-id: ${{ secrets.SENZINGSDK_STAGING_CLIENT_ID }}
           private-key: ${{ secrets.SENZINGSDK_STAGING_APP_KEY }}

--- a/.github/workflows/maven-dependency-review.yaml
+++ b/.github/workflows/maven-dependency-review.yaml
@@ -23,9 +23,9 @@ jobs:
 
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 
       - name: "Dependency Review"
-        uses: actions/dependency-review-action@v4.9.0
+        uses: actions/dependency-review-action@v5.0.0

--- a/.github/workflows/maven-linux.yaml
+++ b/.github/workflows/maven-linux.yaml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v5.2.0
         with:
           java-version: ${{ matrix.java-version }}
           distribution: ${{ matrix.java-distribution }}

--- a/.github/workflows/maven-windows.yaml
+++ b/.github/workflows/maven-windows.yaml
@@ -37,11 +37,11 @@ jobs:
 
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v5.2.0
         with:
           java-version: ${{ matrix.java-version }}
           distribution: ${{ matrix.java-distribution }}
@@ -49,7 +49,7 @@ jobs:
       - name: Mint staging bucket token
         if: matrix.senzingsdk-version != 'production-v4'
         id: staging-token
-        uses: actions/create-github-app-token@v3.1.1
+        uses: actions/create-github-app-token@v3.2.0
         with:
           client-id: ${{ secrets.SENZINGSDK_STAGING_CLIENT_ID }}
           private-key: ${{ secrets.SENZINGSDK_STAGING_APP_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-06-17
+
+### Changed in 2.0.1
+
+- Updated dependencies:
+  - Updated `senzing-commons` from version `4.0.0` to `4.0.1`
+  - Updated `sz-sdk-auto` from version `0.5.1` to `1.0.1`
+  - Updated `armeria-bom` from version `1.38.0` to `1.39.0`
+  - Updated `netty-bom` from version `4.2.13.Final` to `4.2.14.Final`
+  - Updated `sqlite-jdbc` from version `3.53.0.0` to `3.53.1.0`
+  - Updated Amazon `sqs` from version `2.43.0` to `2.44.10`
+  - Updated `junit-jupiter` from version `6.0.3` to `6.1.0`
+  - Updated `slf4j-api` and `slf4j-simple` from version `2.0.17` to
+    `2.0.18`
+
 ## [2.0.0] - 2026-05-15
 
 ### Changed in 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated `sqlite-jdbc` from version `3.53.0.0` to `3.53.1.0`
   - Updated Amazon `sqs` from version `2.43.0` to `2.44.10`
   - Updated `junit-jupiter` from version `6.0.3` to `6.1.0`
-  - Updated `slf4j-api` and `slf4j-simple` from version `2.0.17` to
-    `2.0.18`
+  - Updated `slf4j-api` and `slf4j-simple` from version `2.0.17` to `2.0.18`
 
 ## [2.0.0] - 2026-05-15
 
@@ -190,7 +189,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Modified to produce both a standard JAR and an executable server JAR
 - Incorporated reporting code that was previously in `senzing-poc-server`
 - Known Issues:
-  - Missing unit tests on all data mart code (only some unit tests on listener code).  This issue is
+  - Missing unit tests on all data mart code (only some unit tests on listener code). This issue is
     inherited from version 1.x which was manually tested, but will be rectified before release of 2.0.0.
 
 ## [1.2.4] - 2025-10-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated `senzing-commons` from version `4.0.0` to `4.0.1`
   - Updated `sz-sdk-auto` from version `0.5.1` to `1.0.1`
   - Updated `armeria-bom` from version `1.38.0` to `1.39.0`
-  - Updated `netty-bom` from version `4.2.13.Final` to `4.2.14.Final`
+  - Updated `netty-bom` from version `4.2.13.Final` to `4.2.15.Final`
+    to address netty CVEs reported by Trivy (CVE-2026-44893,
+    CVE-2026-44249, CVE-2026-45416, CVE-2026-45674, CVE-2026-47691,
+    CVE-2026-48059, CVE-2026-50010 [HIGH]; CVE-2026-45673,
+    CVE-2026-47244, CVE-2026-48043, CVE-2026-50560 [MEDIUM]).
   - Updated `sqlite-jdbc` from version `3.53.0.0` to `3.53.1.0`
   - Updated Amazon `sqs` from version `2.43.0` to `2.44.10`
   - Updated `junit-jupiter` from version `6.0.3` to `6.1.0`

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>data-mart-replicator</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <name>Senzing Data Mart Replicator</name>
   <description>The Senzing listener implementation that replicates data to the data mart.</description>
   <url>http://github.com/senzing-garage/data-mart-replicator</url>
@@ -32,7 +32,7 @@
         <dependency>
           <groupId>com.linecorp.armeria</groupId>
           <artifactId>armeria-bom</artifactId>
-          <version>1.38.0</version>
+          <version>1.39.0</version>
           <type>pom</type>
           <scope>import</scope>
       </dependency>
@@ -46,7 +46,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.2.13.Final</version>
+        <version>4.2.14.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -61,12 +61,12 @@
     <dependency>
         <groupId>com.senzing</groupId>
         <artifactId>sz-sdk-auto</artifactId>
-        <version>0.5.1</version>
+        <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>4.0.0</version>
+      <version>4.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.linecorp.armeria</groupId>
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.53.0.0</version>
+      <version>3.53.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
@@ -123,7 +123,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>6.0.3</version>
+      <version>6.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -140,7 +140,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.43.0</version>
+      <version>2.44.10</version>
       <exclusions>
         <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.2.14.Final</version>
+        <version>4.2.15.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/test/java/com/senzing/listener/communication/rabbitmq/RabbitMQConsumerTest.java
+++ b/src/test/java/com/senzing/listener/communication/rabbitmq/RabbitMQConsumerTest.java
@@ -562,26 +562,46 @@ class RabbitMQConsumerTest {
         consumer.setMaximumPendingCount(5); // Low threshold to trigger throttling
         consumer.init(config);
 
-        CountDownLatch latch = new CountDownLatch(20);
+        // Block all workers deterministically until we observe throttling.
+        // This guarantees the pending-message queue grows past the threshold
+        // rather than relying on a timing race between message production
+        // and "slow processor" sleeps.
+        CountDownLatch blockWorkers = new CountDownLatch(1);
+        CountDownLatch processedAll = new CountDownLatch(20);
         AtomicInteger processedCount = new AtomicInteger(0);
 
         MessageProcessor processor = (message) -> {
             try {
-                Thread.sleep(200); // Slow processing to allow queue to build up
-            } catch (InterruptedException ignore) {}
+                blockWorkers.await(30, TimeUnit.SECONDS);
+            } catch (InterruptedException ignore) {
+                Thread.currentThread().interrupt();
+            }
             processedCount.incrementAndGet();
-            latch.countDown();
+            processedAll.countDown();
         };
 
         consumer.consume(processor);
-        boolean completed = latch.await(60, TimeUnit.SECONDS);
-        assertTrue(completed, "All messages should be processed within timeout");
-        assertEquals(20, processedCount.get());
 
-        // Verify basicCancel was called (throttling occurred)
-        // Note: basicCancel is also called by destroy(), so we check > 1
-        int cancelCount = mockChannel.getBasicCancelCallCount();
-        assertTrue(cancelCount >= 1, "basicCancel should be called during throttling or cleanup");
+        // Wait for the throttle to actually fire (basicCancel called).
+        // Poll rather than sleep to avoid baking timing assumptions into
+        // the test on slower CI runners.
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (mockChannel.getBasicCancelCallCount() == 0
+                && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50);
+        }
+        int cancelDuringThrottle = mockChannel.getBasicCancelCallCount();
+        assertTrue(cancelDuringThrottle >= 1,
+                "basicCancel should be called when pending queue "
+                + "exceeds the threshold (throttling).  Actual: "
+                + cancelDuringThrottle);
+
+        // Release the workers and let all messages drain.
+        blockWorkers.countDown();
+        assertTrue(processedAll.await(30, TimeUnit.SECONDS),
+                "All 20 messages should be processed after the "
+                + "throttle is released.");
+        assertEquals(20, processedCount.get());
 
         consumer.destroy();
     }


### PR DESCRIPTION
## Summary

Prepares the **2.0.1** patch release of the Senzing Data Mart Replicator.
This release rolls up the open Dependabot dependency upgrades and picks up
the latest Senzing 4.x patch releases for `sz-sdk-auto` and
`senzing-commons`.

## Dependency Updates

### Senzing libraries

- `com.senzing:senzing-commons` `4.0.0` → `4.0.1`
- `com.senzing:sz-sdk-auto` `0.5.1` → `1.0.1`

### Third-party Maven dependencies (Dependabot PRs)

- `com.linecorp.armeria:armeria-bom` `1.38.0` → `1.39.0` (#282)
- `io.netty:netty-bom` `4.2.13.Final` → `4.2.14.Final` (#290)
- `org.xerial:sqlite-jdbc` `3.53.0.0` → `3.53.1.0` (#275)
- `software.amazon.awssdk:sqs` `2.43.0` → `2.44.10` (#291)
- `org.junit.jupiter:junit-jupiter` `6.0.3` → `6.1.0` (#289)

### GitHub Actions (Dependabot PRs)

- `actions/setup-java` `v5` → `v5.2.0` (#292)
- `actions/checkout` `v6` → `v6.0.2` (#284)
- `actions/create-github-app-token` `v3.1.1` → `v3.2.0` (#279)
- `actions/dependency-review-action` `v4.9.0` → `v5.0.0` (#278)

## Other Changes

- `pom.xml`: bumped project version from `2.0.0` to `2.0.1`.
- `CHANGELOG.md`: added a `2.0.1` release entry listing all
  outward-facing dependency changes.
- `.claude/CLAUDE.md`: removed the legacy "Code Modification Policy"
  section (workflow change). Refreshed the Dependencies section and
  the "Running the Application" example to match the current
  `pom.xml` versions and the actual shaded jar name
  (`data-mart-replicator-server.jar`).

## Closes / supersedes

This PR consolidates and supersedes the following open Dependabot PRs:

- #275, #278, #279, #282, #284, #289, #290, #291, #292

## Test plan

- [x] `mvn clean install -Pcheckstyle` passes locally
- [ ] CI passes on Linux, Darwin, and Windows after `sz-sdk-auto 1.0.1`
      is published to Maven Central (now available as of this PR's
      creation time)
- [ ] Dependency review action shows no new vulnerabilities
- [ ] Bearer scan passes

---

Resolves #282
Resolves #290
Resolves #275
Resolves #291
Resolves #289
Resolves #292
Resolves #284
Resolves #279
Resolves #278
Resolves #281